### PR TITLE
Update to use 7.58 (SA-CORE-2018-002)

### DIFF
--- a/drupal-7/.extensions/drupal/extension.py
+++ b/drupal-7/.extensions/drupal/extension.py
@@ -12,9 +12,9 @@ _log = logging.getLogger('drupal')
 
 
 DEFAULTS = utils.FormattedDict({
-    'DRUPAL_VERSION': '7.57',
+    'DRUPAL_VERSION': '7.58',
     'DRUPAL_PACKAGE': 'drupal-{DRUPAL_VERSION}.tar.gz',
-    'DRUPAL_HASH': '44dec95a0ef56c4786785f575ac59a60',
+    'DRUPAL_HASH': 'c59949bcfd0d68b4f272bc05a91d4dc6',
     'DRUPAL_URL': 'http://ftp.drupal.org/files/projects/{DRUPAL_PACKAGE}'
 })
 


### PR DESCRIPTION
Highly critical remote code execution vulnerability in 7.57 and below.